### PR TITLE
Add setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ Edits a piece of writing to remove patterns commonly associated with LLM-generat
 /de-llmify [path/to/file.md or inline text]
 ```
 
+## Setup
+
+Add this repo path to `permissions.additionalDirectories` in `~/.claude/settings.json`:
+
+```json
+"permissions": {
+  "additionalDirectories": [
+    "/path/to/dev-rel-skills"
+  ]
+}
+```
+
+Claude Code will automatically discover and load all skills from `.claude/skills/` in this repo, alongside any existing skills you already have configured.
+
+**What gets loaded:** skills only. Hooks, subagents, and commands in `.claude/` are ignored. CLAUDE.md/rules are also ignored unless `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` is set.
+
+See the [Claude Code permissions docs](https://code.claude.com/docs/en/permissions#working-directories) and [skills docs](https://code.claude.com/docs/en/skills#skills-from-additional-directories) for more detail.
+
 ## Workflow
 
 A typical dev-rel workflow using these skills:


### PR DESCRIPTION
## Add setup instructions to README

Documents how to enable the dev-rel skills in Claude Code by adding the repo path to `permissions.additionalDirectories` in `~/.claude/settings.json`.

**Note:** There is a known bug ([anthropics/claude-code#30064](https://github.com/anthropics/claude-code/issues/30064)) where `additionalDirectories` does not currently load skills as documented.

As a temporary workaround, symlink the skills directory into your project's `.claude/` folder:

```bash
ln -s /path/to/dev-rel-skills/.claude/skills /path/to/your-project/.claude/skills
```

Note this only works if your project doesn't already have a `.claude/skills/` directory.

The `additionalDirectories` config is still the recommended setup — it will work automatically once the bug is fixed.
