### PR TITLE
Generalize skills to work with any repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,19 +10,32 @@ A collection of Claude Code agent skills for developer relations work. Skills ar
 
 Each skill lives in `skills/<skill-name>/SKILL.md`. Skills are designed to work as a pipeline:
 
-1. `/hn-scout` — Scans Hacker News front page for AI-related posts, scores each for mellea integration potential, and generates concrete demo ideas
-2. `/get-blog-candidates` — Fetches merged PRs from `generative-computing/mellea`, scores each by blog potential, and outputs a ranked table
-3. `/release-blog` — Drafts a full release post from the latest GitHub release, scoring PRs into Highlight (≥50), Mention (10–49), and Skip (<10) tiers
-4. `/write-technical-blog` — Deep-dive post guide drawing on best practices from Stripe, GitHub, Cloudflare, HashiCorp, and Google engineering blogs
-5. `/write-tweet` — Generates tweet threads with proven opening formulas and per-announcement-type content rules
-6. `/de-llmify` — Edits writing to remove LLM-generated text patterns before publishing
-7. `/validate-snippets` — Extracts fenced code blocks from writing, executes each, and reports pass/fail/skip results
+1. `/hn-scout` — Scans Hacker News front page for AI-related posts, scores each for mellea integration potential, and generates concrete demo ideas. **Project-specific to mellea.** For any other project, use `/hn-scout-generic`.
+2. `/hn-scout-generic` — Same as `/hn-scout`, but infers the target project's capabilities from its README at runtime, so it works for any repo.
+3. `/get-blog-candidates` — Fetches merged PRs from the current repo, scores each by blog potential, and outputs a ranked table.
+4. `/release-blog` — Drafts a full release post from the latest GitHub release, scoring PRs into Highlight (≥50), Mention (10–49), and Skip (<10) tiers.
+5. `/write-technical-blog` — Deep-dive post guide drawing on best practices from Stripe, GitHub, Cloudflare, HashiCorp, and Google engineering blogs.
+6. `/write-tweet` — Generates tweet threads with proven opening formulas and per-announcement-type content rules.
+7. `/de-llmify` — Edits writing to remove LLM-generated text patterns before publishing.
+8. `/validate-snippets` — Extracts fenced code blocks from writing, executes each, and reports pass/fail/skip results.
 
 Skills can be used independently but typically flow sequentially: scout → discover → draft → validate → promote.
 
+## Target Repo Resolution
+
+Skills that interact with GitHub resolve the target repo in this order:
+
+1. An explicit `--repo owner/repo` flag on the invocation.
+2. Auto-detection from the current working directory's git remote
+   (`gh repo view --json nameWithOwner -q .nameWithOwner`).
+3. If both fail, the skill asks the user.
+
+This means running any of these skills inside a cloned repo "just works" —
+no configuration needed.
+
 ## External Dependency
 
-All skills that fetch GitHub data rely on the `gh` CLI being installed and authenticated. Skills use `gh pr list`, `gh pr view`, `gh release view`, and `gh api`. The `/hn-scout` skill uses the public Hacker News Firebase API (`hacker-news.firebaseio.com`) and WebFetch for reading linked articles.
+All skills that fetch GitHub data rely on the `gh` CLI being installed and authenticated. Skills use `gh pr list`, `gh pr view`, `gh release view`, and `gh api`. The `/hn-scout` and `/hn-scout-generic` skills use the public Hacker News Firebase API (`hacker-news.firebaseio.com`) and WebFetch for reading linked articles.
 
 ## Output Files
 
@@ -37,4 +50,13 @@ See `demos/` for real examples of each output type.
 
 ## Adding or Modifying Skills
 
-When editing SKILL.md files, the default target repo is `generative-computing/mellea`. Update the repo reference in the relevant SKILL.md if repurposing a skill for a different project.
+Most skills are repo-agnostic and auto-detect the target repo from the
+working directory (see "Target Repo Resolution" above). The one exception is
+`/hn-scout`, which bakes in mellea's capabilities for high-quality fit
+scoring; the generic equivalent is `/hn-scout-generic`, which reads
+capabilities from the target repo's README at runtime.
+
+When adding new skills, prefer the auto-detect pattern over hardcoding a
+repo. Keep project-specific scoring rubrics parameterized (or gated behind
+a `-<project>` suffix in the skill name) so the skill can be reused across
+repos.

--- a/README.md
+++ b/README.md
@@ -4,25 +4,35 @@ A collection of Claude Code agent skills for developer relations work. These ski
 
 ## Skills
 
+> **Target repo resolution.** Skills that hit GitHub use `--repo owner/repo` if passed, otherwise auto-detect from the current working directory's git remote (`gh repo view --json nameWithOwner`). Running any skill inside a cloned repo "just works" — no config needed.
+
 ### `/hn-scout`
 
-Scans the Hacker News front page for AI-related posts and evaluates each for integration or demo potential with a target project. Scores posts on two axes — fit (how naturally the project applies) and buzz (how much visibility it could get) — then generates concrete demo ideas for top-scoring opportunities. Writes output to `hn-scout-YYYY-MM-DD.md`.
+Scans the Hacker News front page for AI-related posts and evaluates each for mellea integration or demo potential. Scores posts on fit (how naturally mellea applies) and buzz (how much visibility it could get) and generates concrete demo ideas for top-scoring opportunities. **This variant is hand-tuned for mellea.** For any other project, use `/hn-scout-generic`. Writes output to `hn-scout-YYYY-MM-DD.md`.
 
 ```
 /hn-scout [--top N]
 ```
 
-### `/get-blog-candidates`
+### `/hn-scout-generic`
 
-Fetches merged PRs from a GitHub repo and ranks them by blog/demo potential. Scores each PR on signals like `feat:` prefix, lines changed, and whether it touched `docs/examples/`. Outputs a ranked table with a "Top picks" callout so you can quickly decide what to write about next.
+Same as `/hn-scout`, but infers the target project's capabilities from its README at runtime so it works for any repo. Use this in any project that isn't mellea. Writes output to `hn-scout-YYYY-MM-DD.md`.
 
 ```
-/get-blog-candidates [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--limit N]
+/hn-scout-generic [--repo owner/repo] [--top N]
+```
+
+### `/get-blog-candidates`
+
+Fetches merged PRs from the current repo and ranks them by blog/demo potential. Detects whether the repo uses Conventional Commits, labels, or free-form PR titles and picks a scoring rubric to match. Outputs a ranked table with a "Top picks" callout so you can quickly decide what to write about next.
+
+```
+/get-blog-candidates [--repo owner/repo] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--limit N]
 ```
 
 ### `/release-blog`
 
-Takes the latest GitHub release, scores all its PRs by blog-worthiness, identifies a narrative theme, and drafts a full release blog post. Highlight-tier PRs get their own sections with before/after code; lower-scoring PRs are grouped into an "Other Improvements" section. Writes the result to `blog-release-vX.Y.Z.md`.
+Takes the latest GitHub release, scores all its PRs by blog-worthiness, identifies a narrative theme, and drafts a full release blog post. Highlight-tier PRs get their own sections with before/after code; lower-scoring PRs are grouped into an "Other Improvements" section. Auto-detects the repo's package ecosystem (pip, npm, cargo, go, gem, maven/gradle) to emit the right upgrade command. Writes the result to `blog-release-vX.Y.Z.md`.
 
 ```
 /release-blog [--tag vX.Y.Z] [--repo owner/repo]

--- a/skills/get-blog-candidates/SKILL.md
+++ b/skills/get-blog-candidates/SKILL.md
@@ -1,50 +1,81 @@
 ---
 name: get-blog-candidates
 description: >-
-  Fetch and rank merged PRs from generative-computing/mellea by their likelihood
-  of being good blog or demo candidates. Scores on: feat label/prefix, lines of
+  Fetch and rank merged PRs from the current repository by their likelihood of
+  being good blog or demo candidates. Scores on: feat label/prefix, lines of
   code changed, and presence of docs/examples changes.
 ---
 
-# Rank Mellea PRs for Blog/Demo Candidates
+# Rank PRs for Blog/Demo Candidates
 
-Fetch merged PRs from `generative-computing/mellea` for a given time window and
-rank them by blog/demo potential.
+Fetch merged PRs from the target repository for a given time window and rank
+them by blog/demo potential.
 
 ## Usage
 
 ```
-/get-blog-candidates [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--limit N]
+/get-blog-candidates [--repo owner/repo] [--since YYYY-MM-DD] [--until YYYY-MM-DD] [--limit N]
 ```
 
-Defaults: `--since` = Monday of current week, `--limit` = 30.
+Defaults:
+- `--repo` = auto-detected from the current working directory's git remote
+- `--since` = Monday of current week
+- `--limit` = 30
 
 ---
 
 ## Steps
 
-### 1. Fetch merged PRs with file details
+### 1. Determine the target repo
+
+If `--repo` was passed, use it. Otherwise auto-detect from the working
+directory:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+If that fails (no `gh` auth, not inside a repo, or no `origin` remote),
+ask the user for `owner/repo`.
+
+### 2. Fetch merged PRs with file details
 
 ```bash
 gh pr list \
-  --repo generative-computing/mellea \
+  --repo OWNER/REPO \
   --state merged \
   --search "merged:>SINCE_DATE" \
   --limit LIMIT \
   --json number,title,mergedAt,author,labels,url,additions,deletions,files
 ```
 
-### 2. Score each PR
+### 3. Detect the repo's commit-message convention
 
-Apply the following scoring rubric (higher = better blog/demo candidate):
+Before scoring, sample the first 5-10 PR titles. Classify the repo:
+
+- **Conventional Commits**: most titles start with `feat:`, `fix:`, `chore:`,
+  `docs:`, `refactor:`, etc. Use the **prefix rubric** below.
+- **Label-driven**: titles are free-form, but most PRs carry labels like
+  `enhancement`, `bug`, `feature`, `documentation`. Use the **label rubric**.
+- **Free-form**: neither prefixes nor consistent labels. Fall back to the
+  **content rubric** (lines changed + file paths only).
+
+Note which convention the repo uses in the output.
+
+### 4. Score each PR
+
+Apply the rubric that matches the repo's convention. Higher = better
+blog/demo candidate.
+
+#### Prefix rubric (Conventional Commits repos)
 
 | Signal | Points |
 |--------|--------|
 | Title starts with `feat:` or `feat(` | **+40** |
 | Label `enhancement` or `feature` | **+20** |
 | Title starts with `fix:` | **+5** |
-| Any changed file under `docs/examples/` | **+25** |
-| Any changed file under `docs/docs/` | **+15** |
+| Any changed file under `docs/examples/`, `examples/`, or `samples/` | **+25** |
+| Any changed file under `docs/docs/` or `docs/` (non-example) | **+15** |
 | Any changed `.md` file anywhere | **+10** |
 | Net lines changed (additions + deletions) ≥ 500 | **+15** |
 | Net lines changed ≥ 200 | **+10** |
@@ -52,9 +83,41 @@ Apply the following scoring rubric (higher = better blog/demo candidate):
 | Title starts with `chore:`, `ci:`, `build:`, or `fix: update github` | **-30** (infra noise) |
 | Title starts with `docs:` (docs-only, no examples) | **-10** |
 
+#### Label rubric (label-driven repos)
+
+| Signal | Points |
+|--------|--------|
+| Label `enhancement`, `feature`, or `new-feature` | **+40** |
+| Label `improvement` or `performance` | **+25** |
+| Label `bug`, `bugfix`, or `fix` | **+5** |
+| Label `breaking-change` or `breaking` | **+30** |
+| Any changed file under `docs/examples/`, `examples/`, or `samples/` | **+25** |
+| Any changed file under `docs/` | **+15** |
+| Any changed `.md` file anywhere | **+10** |
+| Net lines changed ≥ 500 | **+15** |
+| Net lines changed ≥ 200 | **+10** |
+| Net lines changed ≥ 50 | **+5** |
+| Label `chore`, `ci`, `build`, `dependencies`, or `infra` | **-30** |
+| Label `documentation` (docs-only, no examples) | **-10** |
+| Author is `dependabot[bot]` or `renovate[bot]` | **-40** |
+
+#### Content rubric (free-form repos)
+
+| Signal | Points |
+|--------|--------|
+| Any changed file under `examples/`, `docs/examples/`, or `samples/` | **+35** |
+| Any changed file under `docs/` | **+20** |
+| Any changed `.md` file anywhere | **+10** |
+| Net lines changed ≥ 500 | **+25** |
+| Net lines changed ≥ 200 | **+15** |
+| Net lines changed ≥ 50 | **+5** |
+| Title contains keywords: `add`, `new`, `introduce`, `support` | **+15** |
+| Title contains keywords: `fix`, `bump`, `update dep`, `typo` | **-20** |
+| Author is `dependabot[bot]` or `renovate[bot]` | **-40** |
+
 Compute `score` for each PR. Sort descending.
 
-### 3. Output ranked table
+### 5. Output ranked table
 
 Print a markdown table with columns:
 
@@ -64,6 +127,12 @@ Print a markdown table with columns:
 The **Signals** column should list which signals fired, e.g.:
 `feat prefix, docs/examples touched, 1811 lines`
 
+Above the table, note which repo and which rubric was used:
+
+```
+Repo: owner/repo — rubric: Conventional Commits (prefix-based)
+```
+
 Then add a short section **"Top picks"** calling out the #1 and #2 PRs with a
 one-sentence explanation of why each is a good candidate.
 
@@ -71,9 +140,12 @@ one-sentence explanation of why each is a good candidate.
 
 ## Scoring Notes
 
-- PRs with `docs/examples/` changes are high-value because they already have
+- PRs with example/sample changes are high-value because they already have
   runnable demo material.
 - Large line counts (≥ 500) indicate substantial new functionality.
-- Infra PRs (`chore:`, `ci:`, `fix: update github action`) are penalized
-  because they rarely make good blog content.
-- If two PRs tie, prefer the one with `docs/examples/` changes.
+- Infra PRs (dep bumps, CI, chores) are penalized because they rarely make
+  good blog content.
+- If two PRs tie, prefer the one with example changes.
+- Example directory paths vary by project (`examples/`, `docs/examples/`,
+  `samples/`, `demo/`, etc.). The rubrics cover the common ones; if a repo
+  uses something else, note it and adjust inline.

--- a/skills/hn-scout-generic/SKILL.md
+++ b/skills/hn-scout-generic/SKILL.md
@@ -42,6 +42,38 @@ gh repo view --json nameWithOwner -q .nameWithOwner
 
 If that fails, ask the user for `owner/repo`.
 
+**First, check for a hand-tuned profile file** at
+`.claude/hn-scout-profile.md` in the target repo. This file (if present) is
+maintained by the project and carries higher-quality capability bullets and
+a custom fit rubric that the project has tuned by hand.
+
+If running inside a local checkout of the target repo, check the working
+directory first:
+
+```bash
+test -f .claude/hn-scout-profile.md && cat .claude/hn-scout-profile.md
+```
+
+Otherwise (or if the local file is missing), try to fetch it from the
+remote:
+
+```bash
+gh api "repos/OWNER/REPO/contents/.claude/hn-scout-profile.md" \
+  --jq .content 2>/dev/null | base64 -d
+```
+
+**If a profile file is found:**
+
+- Use its capability bullets directly as the capabilities profile — do not
+  paraphrase or "improve" them.
+- If the profile file defines a custom fit rubric (a point table scoped to
+  this project's sweet spot), use that rubric verbatim in Step 5 in place of
+  the generic fit rubric. Record in the output that a hand-tuned rubric was
+  used.
+- Skip the README inference below.
+
+**If no profile file is found**, fall back to README inference.
+
 Fetch the README and repo metadata:
 
 ```bash
@@ -63,7 +95,9 @@ Primary use cases: <2-4 scenarios the README emphasizes>
 
 Be faithful to the README — do not invent capabilities. If the README is
 thin (< 200 words) or missing, ask the user for a one-paragraph project
-description before continuing.
+description before continuing. In that case, also suggest the user create a
+`.claude/hn-scout-profile.md` file to get higher-quality fit scoring on
+future runs.
 
 Keep this profile in memory for all subsequent scoring.
 
@@ -132,9 +166,13 @@ Score each post on two axes:
 
 #### Fit score (0-50): How naturally does the project apply?
 
-Evaluate each post against the capabilities profile. A post scores high on
-fit when **at least one of the project's key capabilities or integrations
-directly addresses something the post is about**.
+**If the profile file from Step 1 defined a custom fit rubric, use that
+rubric verbatim and skip the generic table below.** A hand-tuned rubric
+reflects the project's actual sweet spot better than generic heuristics.
+
+Otherwise, evaluate each post against the capabilities profile. A post
+scores high on fit when **at least one of the project's key capabilities or
+integrations directly addresses something the post is about**.
 
 | Signal | Points |
 |--------|--------|
@@ -192,6 +230,8 @@ directory.
 # HN Scout Report — YYYY-MM-DD
 
 > Project: <name> (OWNER/REPO)
+> Profile source: <`.claude/hn-scout-profile.md` | README inference>
+> Rubric: <hand-tuned (from profile) | generic>
 > Scanned top {N} Hacker News stories. Found {X} AI-relevant posts.
 > Generated {Y} demo opportunities.
 
@@ -268,6 +308,58 @@ capability from the profile genuinely applied.}
 - **Think like a developer, not a marketer.** The content angle should be
   genuinely useful or interesting, not "look at our product." The best
   bandwagon content teaches something while naturally showcasing the tool.
+
+---
+
+## Profile File Format
+
+Projects that want higher-quality fit scoring can commit a
+`.claude/hn-scout-profile.md` file to their repo. When present, it
+overrides README-based inference.
+
+A profile file has two sections:
+
+### 1. Capabilities
+
+A short, hand-curated description of what the project is and what it does
+well. Use the same shape as the README-inferred profile:
+
+```markdown
+## Capabilities
+
+Project: <name>
+One-liner: <what it does in one sentence>
+Primary language: <language>
+Key capabilities:
+- <capability 1>
+- <capability 2>
+- ...
+Integrations: <libraries, providers, frameworks>
+Primary use cases:
+- <use case 1>
+- <use case 2>
+```
+
+### 2. Fit rubric (optional)
+
+A custom point table that replaces the generic fit rubric in Step 5. Use
+this when the project has a well-understood sweet spot that generic
+heuristics would mis-score.
+
+```markdown
+## Fit rubric
+
+| Signal | Points |
+|--------|--------|
+| Post about <the project's bullseye use case> | **+50** |
+| Post about <strong adjacent use case> | **+40** |
+| Post about <a provider/tool we already integrate with> | **+35** |
+| Post about <adjacent pattern we could support> | **+15** |
+| Post about AI but far from sweet spot | **+5** |
+```
+
+Keep each signal concrete (name specific patterns, providers, or use cases
+— not vague categories). Take the highest applicable signal; don't stack.
 
 ---
 

--- a/skills/hn-scout-generic/SKILL.md
+++ b/skills/hn-scout-generic/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: hn-scout-generic
+description: >-
+  Scan Hacker News front page for AI-related posts, then evaluate each for
+  integration or demo potential with the current project (inferred from the
+  repo's README). Outputs a ranked list of bandwagon opportunities with
+  concrete demo ideas.
+---
+
+# HN Scout (Generic): Find Bandwagon Opportunities for Any Project
+
+Scan the Hacker News front page for AI-related posts, then evaluate whether
+the current project could be used with or alongside whatever is being
+discussed. The goal is to find trending topics where the project has a
+credible angle — via a demo, blog post, integration, or Show HN.
+
+Unlike `/hn-scout`, this variant does **not** bake in any specific project's
+capabilities. It infers what the project is about from the repo's README at
+runtime, so it works for any repo.
+
+## Usage
+
+```
+/hn-scout-generic [--repo owner/repo] [--top N]
+```
+
+Defaults:
+- `--repo` = auto-detected from the current working directory's git remote
+- `--top 30` (number of HN front page items to scan)
+
+---
+
+## Steps
+
+### 1. Determine the target project and build a capabilities profile
+
+Resolve the repo:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+If that fails, ask the user for `owner/repo`.
+
+Fetch the README and repo metadata:
+
+```bash
+gh repo view OWNER/REPO --json description,topics,primaryLanguage
+gh api repos/OWNER/REPO/readme --jq .content | base64 -d
+```
+
+From those sources, extract a **capabilities profile** in this shape:
+
+```
+Project: <name>
+One-liner: <repo description or first paragraph of README>
+Primary language: <from repo metadata>
+Topics: <github topics list>
+Key capabilities: <3-8 bullets extracted from README features/highlights>
+Integrations: <libraries, providers, tools, frameworks the project supports>
+Primary use cases: <2-4 scenarios the README emphasizes>
+```
+
+Be faithful to the README — do not invent capabilities. If the README is
+thin (< 200 words) or missing, ask the user for a one-paragraph project
+description before continuing.
+
+Keep this profile in memory for all subsequent scoring.
+
+### 2. Fetch the Hacker News front page
+
+Use the Hacker News API to get the current top story IDs, then fetch
+details for each:
+
+```bash
+# Get top story IDs (returns up to 500, we take the first N)
+curl -s "https://hacker-news.firebaseio.com/v0/topstories.json" | python3 -c "
+import json, sys
+ids = json.load(sys.stdin)[:TOP_N]
+print(json.dumps(ids))
+"
+```
+
+Then for each story ID, fetch the item:
+
+```bash
+curl -s "https://hacker-news.firebaseio.com/v0/item/{id}.json"
+```
+
+Collect: `id`, `title`, `url`, `score`, `descendants` (comment count), `by`,
+`time`.
+
+To avoid excessive API calls, batch the fetches and run them in parallel
+where possible.
+
+### 3. Filter for AI relevance
+
+Score each post for AI relevance using the title, URL domain, and (when
+available) a quick fetch of the linked content.
+
+**AI-relevance signals** (any match = relevant):
+
+| Signal | Weight |
+|--------|--------|
+| Title contains: LLM, GPT, Claude, AI, ML, model, inference, transformer, embedding, RAG, agent, fine-tun, prompt, diffusion, neural, deep learning, GenAI, generative, multimodal, vision model, language model, copilot, assistant, chatbot, reasoning, chain-of-thought, MCP, tool use, function calling | High |
+| Title contains any term from the project's topics/capabilities | High |
+| URL domain is: openai.com, anthropic.com, huggingface.co, arxiv.org (cs.AI/cs.CL/cs.LG), ollama.com, together.ai, replicate.com, deepmind.google, ai.meta.com | High |
+| HN score >= 100 AND title mentions any programming/tech concept alongside AI | Medium |
+
+Discard posts with no AI relevance signals. Keep the rest for scoring.
+
+### 4. Read linked content for relevant posts
+
+For each AI-relevant post, use WebFetch to read the linked URL. Extract:
+
+- **What it is**: the project, paper, tool, or announcement in one sentence
+- **Core technology**: what stack/language/framework it uses
+- **Key capability**: what it does that people care about
+- **Why it's trending**: what makes this interesting right now (new release,
+  benchmark result, controversy, etc.)
+
+If the URL is inaccessible (paywall, PDF-only, etc.), work from the title
+and HN comments thread at `https://news.ycombinator.com/item?id={id}`
+instead.
+
+### 5. Score each post for project-fit opportunity
+
+For each AI-relevant post, evaluate how naturally the current project
+applies, using the capabilities profile from Step 1.
+
+Score each post on two axes:
+
+#### Fit score (0-50): How naturally does the project apply?
+
+Evaluate each post against the capabilities profile. A post scores high on
+fit when **at least one of the project's key capabilities or integrations
+directly addresses something the post is about**.
+
+| Signal | Points |
+|--------|--------|
+| Post's subject matter is a direct use case the project's README emphasizes | **+50** |
+| Post discusses a pain point that one of the project's capabilities explicitly solves | **+40** |
+| Post is about a library/provider/tool that the project already integrates with | **+35** |
+| Post overlaps with the project's primary language and a listed capability | **+30** |
+| Post is adjacent to the project's domain but doesn't directly use any capability | **+15** |
+| Post is about AI broadly, but in a domain far from the project's sweet spot | **+5** |
+
+Take the highest applicable signal (don't stack). For each score, record
+**which specific capability** drove it — this becomes the credibility
+check.
+
+#### Buzz score (0-50): How much visibility could we get?
+
+| Signal | Points |
+|--------|--------|
+| HN score >= 300 | **+30** |
+| HN score >= 150 | **+20** |
+| HN score >= 50 | **+10** |
+| Comment count >= 200 | **+20** |
+| Comment count >= 100 | **+15** |
+| Comment count >= 50 | **+10** |
+
+**Total opportunity score** = Fit score + Buzz score (max 100).
+
+### 6. Generate demo ideas
+
+For each post scoring >= 40 total, generate a concrete demo concept:
+
+- **Demo title**: a short, punchy name for the demo (e.g., "<Project> x
+  Qwen2.5: Structured extraction in 10 lines")
+- **What to build**: 2-3 sentences describing a small, buildable demo
+- **Project capabilities used**: which specific capabilities from the
+  profile this showcases
+- **Effort estimate**: S (afternoon hack), M (1-2 days), L (3-5 days)
+- **Content angle**: how to frame this for maximum developer interest
+  (blog post title, tweet hook, Show HN title)
+- **Timeliness**: how quickly we need to ship to ride the wave (hours,
+  days, this week)
+
+If no capability from the profile genuinely applies, **do not invent
+one**. Drop the post from the demo ideas section and note it under
+"Skipped" with a one-phrase reason.
+
+### 7. Output ranked results
+
+Write a markdown file `hn-scout-YYYY-MM-DD.md` in the current working
+directory.
+
+#### Output format
+
+```markdown
+# HN Scout Report — YYYY-MM-DD
+
+> Project: <name> (OWNER/REPO)
+> Scanned top {N} Hacker News stories. Found {X} AI-relevant posts.
+> Generated {Y} demo opportunities.
+
+## Capabilities profile used for fit-scoring
+
+- <capability 1>
+- <capability 2>
+- ...
+
+---
+
+## Top Opportunities
+
+### 1. [Post Title](HN link) — Score: XX/100
+
+> {one-line summary of the post}
+
+| | |
+|---|---|
+| **HN Score** | {score} ({comments} comments) |
+| **Fit** | {fit_score}/50 — {which capability applies and why} |
+| **Buzz** | {buzz_score}/50 |
+| **Source** | [{domain}]({url}) |
+
+**Demo idea: {demo title}**
+
+{What to build — 2-3 sentences}
+
+- **Capabilities used**: {list}
+- **Effort**: {S/M/L}
+- **Content angle**: "{blog/tweet/ShowHN title}"
+- **Ship by**: {timeliness}
+
+---
+
+### 2. ...
+
+(repeat for all posts scoring >= 40)
+
+---
+
+## Also Relevant (score 20-39)
+
+| # | Title | Score | Fit | Buzz | Quick take |
+|---|-------|-------|-----|------|------------|
+| ... | ... | ... | ... | ... | one-line note |
+
+---
+
+## Skipped (AI-relevant but low opportunity)
+
+{Bulleted list of titles that were AI-relevant but scored < 20, with a
+one-phrase reason for skipping each — including any posts where no
+capability from the profile genuinely applied.}
+```
+
+---
+
+## Guidance
+
+- **Credibility is paramount.** Only suggest demos where the project
+  genuinely adds value. A forced integration will backfire — developers
+  smell marketing from a mile away. If a post is trending but the project
+  has no natural angle, say so and move on.
+- **Ground every fit claim in the capabilities profile.** If you can't
+  point to a specific bullet in the profile that justifies the fit score,
+  the fit score is wrong.
+- **Speed matters.** HN cycles are 24-48 hours. Flag anything where the
+  window is closing. A mediocre demo shipped today beats a polished one
+  shipped next week.
+- **Concrete beats vague.** "Build a demo" is not an action item. A good
+  demo idea names specific APIs, specific models or providers, and a
+  specific outcome.
+- **Think like a developer, not a marketer.** The content angle should be
+  genuinely useful or interesting, not "look at our product." The best
+  bandwagon content teaches something while naturally showcasing the tool.
+
+---
+
+## Related Skills
+
+- `/hn-scout` — the mellea-specific variant with a hand-tuned fit rubric.
+  Prefer this generic version for any other project.

--- a/skills/release-blog/SKILL.md
+++ b/skills/release-blog/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: release-blog
 description: >-
-  Fetch the latest GitHub release for generative-computing/mellea, score and
-  rank its PRs by blog-worthiness, then draft a narrative release blog post
+  Fetch the latest GitHub release for the current repository, score and rank
+  its PRs by blog-worthiness, then draft a narrative release blog post
   highlighting the most impactful changes.
 ---
 
 # Draft a Release Blog Post from the Latest GitHub Release
 
-Fetch the latest release from `generative-computing/mellea`, identify the
-highest-impact changes, and produce a publication-ready blog post draft.
+Fetch the latest release from the target repo, identify the highest-impact
+changes, and produce a publication-ready blog post draft.
 
 ## Usage
 
@@ -17,24 +17,39 @@ highest-impact changes, and produce a publication-ready blog post draft.
 /release-blog [--tag vX.Y.Z] [--repo owner/repo]
 ```
 
-Defaults: `--tag` = latest release, `--repo` = `generative-computing/mellea`.
+Defaults:
+- `--tag` = latest release
+- `--repo` = auto-detected from the current working directory's git remote
 
 ---
 
-## Step 1: Fetch the Release
+## Step 1: Determine the Target Repo
+
+If `--repo` was passed, use it. Otherwise auto-detect:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+If that fails (no `gh` auth, not inside a repo, or no `origin` remote),
+ask the user for `owner/repo`.
+
+---
+
+## Step 2: Fetch the Release
 
 Get the release body and metadata:
 
 ```bash
 # If no tag specified, fetch the latest
-gh release view --repo generative-computing/mellea \
+gh release view --repo OWNER/REPO \
   --json tagName,name,publishedAt,body,url
 ```
 
 If `--tag` was provided, use:
 
 ```bash
-gh release view vX.Y.Z --repo generative-computing/mellea \
+gh release view vX.Y.Z --repo OWNER/REPO \
   --json tagName,name,publishedAt,body,url
 ```
 
@@ -42,7 +57,7 @@ Record: `tagName`, `publishedAt` (format as `Month DD, YYYY`), `body`, `url`.
 
 ---
 
-## Step 2: Extract PR Numbers from the Release Body
+## Step 3: Extract PR Numbers from the Release Body
 
 Parse the release `body` for PR references. They appear as `(#1234)` or
 `#1234` in lines like:
@@ -56,12 +71,12 @@ Extract every PR number mentioned. Deduplicate. You should typically find
 
 ---
 
-## Step 3: Fetch PR Metadata
+## Step 4: Fetch PR Metadata
 
 For each extracted PR number, fetch:
 
 ```bash
-gh pr view PR_NUMBER --repo generative-computing/mellea \
+gh pr view PR_NUMBER --repo OWNER/REPO \
   --json number,title,body,labels,additions,deletions,files,author,mergedAt
 ```
 
@@ -70,24 +85,71 @@ Collect: `title`, `labels[].name`, `additions + deletions` (net lines),
 
 ---
 
-## Step 4: Score Each PR for Blog Prominence
+## Step 5: Detect the Repo's Commit-Message Convention
 
-Apply the scoring rubric below. Higher score = more space in the blog post.
+Sample the first 5-10 PR titles. Classify:
+
+- **Conventional Commits**: most titles start with `feat:`, `fix:`, `chore:`,
+  `docs:`, `refactor:`, etc. Use the **prefix rubric** below.
+- **Label-driven**: titles are free-form but PRs carry labels like
+  `enhancement`, `bug`, `feature`, `documentation`. Use the **label rubric**.
+- **Free-form**: neither. Use the **content rubric**.
+
+---
+
+## Step 6: Score Each PR for Blog Prominence
+
+Apply the rubric that matches the repo's convention. Higher score = more
+space in the blog post.
+
+### Prefix rubric (Conventional Commits repos)
 
 | Signal | Points |
 |--------|--------|
 | Title starts with `feat:` or `feat(` | **+40** |
 | Label `enhancement` or `feature` | **+20** |
-| Any changed file under `docs/examples/` | **+25** |
-| Any changed file under `docs/docs/` | **+15** |
+| Any changed file under `docs/examples/`, `examples/`, or `samples/` | **+25** |
+| Any changed file under `docs/` (non-example) | **+15** |
 | Any changed `.md` file anywhere | **+10** |
 | Net lines changed ≥ 500 | **+15** |
 | Net lines changed ≥ 200 | **+10** |
 | Net lines changed ≥ 50 | **+5** |
-| Label `breaking-change` | **+30** (must be prominently featured) |
+| Label `breaking-change` or title contains `BREAKING` | **+30** (must be prominently featured) |
 | Title starts with `fix:` | **+5** |
 | Title starts with `chore:`, `ci:`, `build:` | **−30** (infra noise) |
 | Author is `dependabot[bot]` or `renovate[bot]` | **−40** (dep bumps) |
+
+### Label rubric (label-driven repos)
+
+| Signal | Points |
+|--------|--------|
+| Label `enhancement`, `feature`, or `new-feature` | **+40** |
+| Label `improvement` or `performance` | **+25** |
+| Label `breaking-change` or `breaking` | **+30** (must be prominently featured) |
+| Label `bug`, `bugfix`, or `fix` | **+5** |
+| Any changed file under `docs/examples/`, `examples/`, or `samples/` | **+25** |
+| Any changed file under `docs/` | **+15** |
+| Any changed `.md` file anywhere | **+10** |
+| Net lines changed ≥ 500 | **+15** |
+| Net lines changed ≥ 200 | **+10** |
+| Net lines changed ≥ 50 | **+5** |
+| Label `chore`, `ci`, `build`, `dependencies`, or `infra` | **−30** |
+| Author is `dependabot[bot]` or `renovate[bot]` | **−40** |
+
+### Content rubric (free-form repos)
+
+| Signal | Points |
+|--------|--------|
+| Any changed file under `examples/`, `docs/examples/`, or `samples/` | **+35** |
+| Any changed file under `docs/` | **+20** |
+| Any changed `.md` file anywhere | **+10** |
+| Net lines changed ≥ 500 | **+25** |
+| Net lines changed ≥ 200 | **+15** |
+| Net lines changed ≥ 50 | **+5** |
+| Title contains `BREAKING` or body mentions breaking change | **+30** |
+| Title contains keywords: `add`, `new`, `introduce`, `support` | **+15** |
+| Title contains keywords: `fix`, `bump`, `update dep`, `typo` | **−20** |
+| Author is `dependabot[bot]` or `renovate[bot]` | **−40** |
 
 Sort PRs descending by score. Assign tiers:
 
@@ -97,7 +159,7 @@ Sort PRs descending by score. Assign tiers:
 
 ---
 
-## Step 5: Identify the Release Theme
+## Step 7: Identify the Release Theme
 
 Look at the **Highlight** PRs and ask: what is the single unifying story?
 
@@ -112,7 +174,7 @@ The theme becomes the **opening hook** of the blog post.
 
 ---
 
-## Step 6: Draft the Blog Post
+## Step 8: Draft the Blog Post
 
 Use the following structure. The post should read like an engineer wrote it,
 not a changelog or press release.
@@ -123,13 +185,13 @@ Follow the pattern from `/write-technical-blog`:
 - Lead with the **outcome or problem solved**, not the version number.
 - Include the project name and version for SEO.
 - Target 50–60 characters.
-- Patterns: `[Feature]: what it enables in Mellea vX.Y.Z` or
-  `How [theme] works in Mellea vX.Y.Z`
+- Patterns: `[Feature]: what it enables in <Project> vX.Y.Z` or
+  `How [theme] works in <Project> vX.Y.Z`
 
 ### Opening Hook (2–3 paragraphs)
 
 - State the problem the reader already has (the "before" world).
-- Name the release and date: "Mellea vX.Y.Z, released [date],"
+- Name the release and date: "<Project> vX.Y.Z, released [date],"
 - State what changes: one sentence on the release theme.
 - Include one concrete metric if available ("reduces boilerplate from 40
   lines to 8", "3× faster on sequential chains").
@@ -188,12 +250,32 @@ Group related fixes together (e.g., "Backend fixes", "CLI improvements") if
 
 ### Upgrade
 
+Detect the repo's package ecosystem by checking which manifest files exist
+at the repo root (use `gh api` or the local working directory). Emit the
+matching install command:
+
+| Manifest detected | Command template |
+|-------------------|------------------|
+| `pyproject.toml`, `setup.py`, or `setup.cfg` | `pip install --upgrade <package>` |
+| `package.json` | `npm install <package>@latest` (or `pnpm`/`yarn` if a lockfile indicates) |
+| `go.mod` | `go get -u <module>` |
+| `Cargo.toml` | `cargo install <crate>` or `cargo update -p <crate>` for lib crates |
+| `Gemfile` or `*.gemspec` | `gem update <gem>` |
+| `pom.xml` or `build.gradle` | Update the version in the build file (show the dependency snippet) |
+| None detected or ambiguous | Use `<upgrade-command>` as a placeholder and note that the maintainer should fill it in |
+
+Derive `<package>`/`<module>` from the manifest when possible (e.g.,
+`[project].name` in `pyproject.toml`, `"name"` in `package.json`, the module
+path in `go.mod`). If the published package name differs from the repo name
+(common for Python projects where the PyPI name ≠ repo name), prefer the
+manifest value.
+
 ```markdown
 ## Upgrading
 
-```bash
-pip install --upgrade mellea
-```
+​```bash
+<detected upgrade command>
+​```
 
 See the [full release notes](RELEASE_URL) for the complete changelog.
 ```
@@ -202,7 +284,7 @@ If there were breaking changes, repeat the migration pointer here.
 
 ---
 
-## Step 7: Self-Review Before Outputting
+## Step 9: Self-Review Before Outputting
 
 Check each item before producing the final post:
 
@@ -235,7 +317,8 @@ preserved for reference):
 
 ```markdown
 <!--
-Drafted from: generative-computing/mellea vX.Y.Z (RELEASE_URL)
+Drafted from: OWNER/REPO vX.Y.Z (RELEASE_URL)
+Rubric: <prefix | label | content>
 Highlight PRs: #N, #N, #N  (score ≥ 50)
 Mention PRs: #N, #N, ...    (score 10–49)
 Skipped PRs: #N, #N, ...    (score < 10, not in post)

--- a/skills/write-technical-blog/SKILL.md
+++ b/skills/write-technical-blog/SKILL.md
@@ -19,9 +19,21 @@ developers.
 /write-technical-blog [topic or PR number or description]
 ```
 
-If given a PR number, fetch its title, description, and changed files first
-(`gh pr view <number> --repo generative-computing/mellea`), then apply the
-framework below.
+If given a PR number, fetch its title, description, and changed files first.
+Determine the target repo in this order:
+
+1. Use `--repo owner/repo` if the user supplied one.
+2. Otherwise auto-detect from the current working directory:
+   `gh repo view --json nameWithOwner -q .nameWithOwner`.
+3. If auto-detection fails, ask the user.
+
+Then run:
+
+```bash
+gh pr view <number> --repo OWNER/REPO
+```
+
+and apply the framework below.
 
 ---
 

--- a/skills/write-tweet/SKILL.md
+++ b/skills/write-tweet/SKILL.md
@@ -20,9 +20,12 @@ engagement on Twitter/X.
 
 ### Input types
 
-**PR number** — fetch context first:
+**PR number** — fetch context first. Auto-detect the repo from the working
+directory (`gh repo view --json nameWithOwner -q .nameWithOwner`), or use
+`--repo owner/repo` if provided:
+
 ```bash
-gh pr view <number> --repo generative-computing/mellea
+gh pr view <number> --repo OWNER/REPO
 ```
 
 **Markdown file (blog post)** — read the file, then extract:


### PR DESCRIPTION
Most skills previously hardcoded generative-computing/mellea as the target
repo. They now auto-detect from the current working directory's git remote
(`gh repo view --json nameWithOwner`), fall back to a `--repo` flag, or
prompt the user as a last resort.

- get-blog-candidates: auto-detect repo + three-rubric scoring (prefix /
  label / content) that adapts to the repo's commit-message convention
- release-blog: same auto-detect + rubric split; upgrade section now picks
  the right install command from the repo's package manifest (pip, npm,
  cargo, go, gem, maven/gradle) with a placeholder fallback
- write-technical-blog, write-tweet: drop hardcoded --repo, add
  auto-detect instructions
- hn-scout-generic (new): copy of hn-scout that reads the target project's
  capabilities from its README at runtime; original hn-scout is left
  unchanged for mellea
- CLAUDE.md, README.md: document the generic behavior and the new skill